### PR TITLE
Export flow-types to types.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
-  "presets": ["es2015", "stage-2", "react", "flow"]
+  "presets": ["es2015", "stage-2", "react", "flow"],
+  "env": {
+    "development": {
+      "plugins": ["flow-react-proptypes"]
+    }
+  }
 }

--- a/dis/types.js
+++ b/dis/types.js
@@ -1,0 +1,66 @@
+// @flow
+
+export type dataProviderType = string =>
+  | Promise<Array<Object | string>>
+  | Array<Object | string>;
+
+export type settingType = {
+  component: ReactClass<*>,
+  dataProvider: dataProviderType,
+  output?: (Object | string, ?string) => string,
+};
+
+export type getTextToReplaceType = (Object | string) => string;
+
+export type triggerType = {
+  [string]: {|
+    output?: (Object | string, ?string) => string,
+    dataProvider: dataProviderType,
+    component: ReactClass<*>,
+  |},
+};
+
+// Textarea
+export type PropsTextarea = {
+  trigger: triggerType,
+  loadingComponent: ReactClass<*>,
+  onChange?: (SyntheticEvent | Event) => void,
+  minChar?: number,
+  value?: string,
+  style?: Object,
+  containerStyle?: Object,
+};
+
+export type StateTextarea = {
+  currentTrigger: ?string,
+  top: number,
+  left: number,
+  actualToken: string,
+  data: ?Array<Object | string>,
+  value: string,
+  dataLoading: boolean,
+  selectionEnd: number,
+  selectionStart: number,
+  component: ?ReactClass<*>,
+};
+
+// Item
+export type PropsItem = {
+  component: ReactClass<*>,
+  onSelectHandler: (Object | string) => void,
+  item: Object | string,
+  onClickHandler: SyntheticEvent => void,
+  selected: boolean,
+};
+
+// List
+export type PropsList = {
+  values: Array<Object | string>,
+  component: ReactClass<*>,
+  getTextToReplace: (Object | string) => string,
+  onSelect: string => void,
+};
+
+export type StateList = {
+  selectedItem: ?Object | ?string,
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint --ext=js --ext=jsx ./src",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",
-    "flow": "flow",
+    "flow": "flow check",
     "test:watch": "jest --watch",
     "dev": "npm run build -- --watch",
     "ci": "flow && jest",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react": ">=15"
   },
   "dependencies": {
+    "rollup-plugin-copy": "^0.2.3",
     "textarea-caret": "3.0.2"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react": ">=15"
   },
   "dependencies": {
+    "babel-plugin-flow-react-proptypes": "^6.1.0",
     "rollup-plugin-copy": "^0.2.3",
     "textarea-caret": "3.0.2"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,8 +5,8 @@ import commonjs from 'rollup-plugin-commonjs';
 import hypothetical from 'rollup-plugin-hypothetical';
 import license from 'rollup-plugin-license';
 import uglify from 'rollup-plugin-uglify';
-import path from 'path';
 import copy from 'rollup-plugin-copy';
+import path from 'path';
 
 export default {
   entry: 'src/index.js',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,12 +6,16 @@ import hypothetical from 'rollup-plugin-hypothetical';
 import license from 'rollup-plugin-license';
 import uglify from 'rollup-plugin-uglify';
 import path from 'path';
+import copy from 'rollup-plugin-copy';
 
 export default {
   entry: 'src/index.js',
   format: 'cjs',
   external: ['react', 'prop-types', 'textarea-caret'],
   plugins: [
+    copy({
+      'src/types.js': 'dist/types.js'
+    }),
     resolve(),
     hypothetical({
       // https://github.com/rollup/rollup-plugin-commonjs/issues/194

--- a/src/Item.jsx
+++ b/src/Item.jsx
@@ -2,13 +2,7 @@
 
 import React from 'react';
 
-type Props = {
-  component: ReactClass<*>,
-  onSelectHandler: (Object | string) => void,
-  item: Object | string,
-  onClickHandler: SyntheticEvent => void,
-  selected: boolean,
-};
+import type { PropsItem } from './types';
 
 export default class Item extends React.Component {
   selectItem = () => {
@@ -16,7 +10,7 @@ export default class Item extends React.Component {
     onSelectHandler(item);
   };
 
-  props: Props;
+  props: PropsItem;
 
   render() {
     const { component: Component, onClickHandler, item, selected } = this.props;
@@ -24,7 +18,9 @@ export default class Item extends React.Component {
     return (
       <li className="rta__item">
         <div
-          className={`rta__entity ${selected === true ? 'rta__entity--selected' : ''}`}
+          className={`rta__entity ${selected === true
+            ? 'rta__entity--selected'
+            : ''}`}
           role="button"
           tabIndex={0}
           onClick={onClickHandler}

--- a/src/List.jsx
+++ b/src/List.jsx
@@ -5,19 +5,10 @@ import React from 'react';
 import Listeners, { KEY_CODES } from './listener';
 import Item from './Item';
 
-type Props = {
-  values: Array<Object | string>,
-  component: ReactClass<*>,
-  getTextToReplace: (Object | string) => string,
-  onSelect: string => void,
-};
-
-type State = {
-  selectedItem: ?Object | ?string,
-};
+import type { PropsList, StateList } from './types';
 
 export default class List extends React.Component {
-  state: State = {
+  state: StateList = {
     selectedItem: null,
   };
 
@@ -31,7 +22,7 @@ export default class List extends React.Component {
     if (values && values[0]) this.selectItem(values[0]);
   }
 
-  componentWillReceiveProps({ values }: Props) {
+  componentWillReceiveProps({ values }: PropsList) {
     if (values && values[0]) this.selectItem(values[0]);
   }
 
@@ -62,7 +53,7 @@ export default class List extends React.Component {
 
   getId = (item: Object | string): string => this.props.getTextToReplace(item);
 
-  props: Props;
+  props: PropsList;
 
   listeners: Array<number> = [];
 

--- a/src/Textarea.jsx
+++ b/src/Textarea.jsx
@@ -1,54 +1,17 @@
 // @flow
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import getCaretCoordinates from 'textarea-caret';
+
+import type {
+  settingType,
+  getTextToReplaceType,
+  PropsTextarea,
+  StateTextarea,
+} from './types';
 
 import Listeners, { KEY_CODES } from './listener';
 import List from './List';
-
-type dataProviderType = string =>
-  | Promise<Array<Object | string>>
-  | Array<Object | string>;
-
-type settingType = {
-  component: ReactClass<*>,
-  dataProvider: dataProviderType,
-  output?: (Object | string, ?string) => string,
-};
-
-type getTextToReplaceType = (Object | string) => string;
-
-type triggerType = {
-  [string]: {|
-    output?: (Object | string, ?string) => string,
-    dataProvider: dataProviderType,
-    component: ReactClass<*>,
-  |},
-};
-
-type Props = {
-  trigger: triggerType,
-  loadingComponent: ReactClass<*>,
-  onChange?: (SyntheticEvent | Event) => void,
-  minChar?: number,
-  value?: string,
-  style?: Object,
-  containerStyle?: Object,
-};
-
-type State = {
-  currentTrigger: ?string,
-  top: number,
-  left: number,
-  actualToken: string,
-  data: ?Array<Object | string>,
-  value: string,
-  dataLoading: boolean,
-  selectionEnd: number,
-  selectionStart: number,
-  component: ?ReactClass<*>,
-};
 
 class ReactTextareaAutocomplete extends React.Component {
   static defaultProps = {
@@ -59,7 +22,7 @@ class ReactTextareaAutocomplete extends React.Component {
     onChange: undefined,
   };
 
-  constructor(props: Props) {
+  constructor(props: PropsTextarea) {
     super(props);
 
     Listeners.add(KEY_CODES.ESC, () => this.closeAutocomplete());
@@ -78,7 +41,7 @@ class ReactTextareaAutocomplete extends React.Component {
     }
   }
 
-  state: State = {
+  state: StateTextarea = {
     top: 0,
     left: 0,
     currentTrigger: null,
@@ -95,7 +58,7 @@ class ReactTextareaAutocomplete extends React.Component {
     Listeners.startListen();
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentWillReceiveProps(nextProps: PropsTextarea) {
     this.update(nextProps);
   }
 
@@ -236,7 +199,7 @@ class ReactTextareaAutocomplete extends React.Component {
     return data;
   };
 
-  update({ value, trigger }: Props) {
+  update({ value, trigger }: PropsTextarea) {
     const { value: oldValue } = this.state;
     const { trigger: oldTrigger } = this.props;
 
@@ -326,7 +289,7 @@ class ReactTextareaAutocomplete extends React.Component {
     );
   };
 
-  props: Props;
+  props: PropsTextarea;
 
   textareaRef: HTMLInputElement;
 
@@ -338,7 +301,7 @@ class ReactTextareaAutocomplete extends React.Component {
       style,
       containerStyle,
       ...otherProps
-    } = this.props;
+    }: PropsTextarea = this.props;
     const { left, top, dataLoading, component, value } = this.state;
 
     const suggestionData = this.getSuggestions();
@@ -381,40 +344,5 @@ class ReactTextareaAutocomplete extends React.Component {
     );
   }
 }
-
-const triggerPropsCheck = ({ trigger }: { trigger: triggerType }) => {
-  if (!trigger) return Error('Invalid prop trigger. Prop missing.');
-
-  const triggers = Object.entries(trigger);
-
-  for (let i = 0; i < triggers.length; i += 1) {
-    const [triggerChar, settings] = triggers[i];
-
-    if (typeof triggerChar !== 'string' || triggerChar.length !== 1) {
-      return Error(
-        'Invalid prop trigger. Keys of the object has to be string.',
-      );
-    }
-
-    // $FlowFixMe
-    const { component, dataProvider } = settings;
-
-    if (!component || typeof component !== 'function') {
-      return Error('Invalid prop trigger: component should be defined.');
-    }
-
-    if (!dataProvider || typeof dataProvider !== 'function') {
-      return Error('Invalid prop trigger: dataProvider should be defined.');
-    }
-  }
-
-  return null;
-};
-
-ReactTextareaAutocomplete.propTypes = {
-  trigger: triggerPropsCheck, //eslint-disable-line
-  loadingComponent: PropTypes.func.isRequired,
-  value: PropTypes.string,
-};
 
 export default ReactTextareaAutocomplete;

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,66 @@
+// @flow
+
+export type dataProviderType = string =>
+  | Promise<Array<Object | string>>
+  | Array<Object | string>;
+
+export type settingType = {
+  component: ReactClass<*>,
+  dataProvider: dataProviderType,
+  output?: (Object | string, ?string) => string,
+};
+
+export type getTextToReplaceType = (Object | string) => string;
+
+export type triggerType = {
+  [string]: {|
+    output?: (Object | string, ?string) => string,
+    dataProvider: dataProviderType,
+    component: ReactClass<*>,
+  |},
+};
+
+// Textarea
+export type PropsTextarea = {
+  trigger: triggerType,
+  loadingComponent: ReactClass<*>,
+  onChange?: (SyntheticEvent | Event) => void,
+  minChar?: number,
+  value?: string,
+  style?: Object,
+  containerStyle?: Object,
+};
+
+export type StateTextarea = {
+  currentTrigger: ?string,
+  top: number,
+  left: number,
+  actualToken: string,
+  data: ?Array<Object | string>,
+  value: string,
+  dataLoading: boolean,
+  selectionEnd: number,
+  selectionStart: number,
+  component: ?ReactClass<*>,
+};
+
+// Item
+export type PropsItem = {
+  component: ReactClass<*>,
+  onSelectHandler: (Object | string) => void,
+  item: Object | string,
+  onClickHandler: SyntheticEvent => void,
+  selected: boolean,
+};
+
+// List
+export type PropsList = {
+  values: Array<Object | string>,
+  component: ReactClass<*>,
+  getTextToReplace: (Object | string) => string,
+  onSelect: string => void,
+};
+
+export type StateList = {
+  selectedItem: ?Object | ?string,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,6 +225,14 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
 babel-core@6, babel-core@6.25.0, babel-core@^6.0.0, babel-core@^6.24.1:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
@@ -249,6 +257,30 @@ babel-core@6, babel-core@6.25.0, babel-core@^6.0.0, babel-core@^6.24.1:
     slash "^1.0.0"
     source-map "^0.5.0"
 
+babel-core@^6.25.0, babel-core@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.0"
+    debug "^2.6.8"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.7"
+    slash "^1.0.0"
+    source-map "^0.5.6"
+
 babel-eslint@7.2.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
@@ -269,6 +301,19 @@ babel-generator@^6.18.0, babel-generator@^6.25.0:
     jsesc "^1.3.0"
     lodash "^4.2.0"
     source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+babel-generator@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.6"
     trim-right "^1.0.1"
 
 babel-helper-bindify-decorators@^6.24.1:
@@ -422,6 +467,15 @@ babel-plugin-external-helpers@6.22.0, babel-plugin-external-helpers@^6.18.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-flow-react-proptypes@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-flow-react-proptypes/-/babel-plugin-flow-react-proptypes-6.1.0.tgz#28570fedfe80df5981496c66ab4440660ba728b2"
+  dependencies:
+    babel-core "^6.25.0"
+    babel-template "^6.25.0"
+    babel-traverse "^6.25.0"
+    babel-types "^6.25.0"
 
 babel-plugin-istanbul@^4.0.0:
   version "4.1.4"
@@ -907,12 +961,31 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
+babel-register@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
+  dependencies:
+    babel-core "^6.26.0"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    home-or-tmp "^2.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    source-map-support "^0.4.15"
+
 babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
@@ -923,6 +996,16 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
     babel-types "^6.25.0"
     babylon "^6.17.2"
     lodash "^4.2.0"
+
+babel-template@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
 
 babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
@@ -938,6 +1021,20 @@ babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
 babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
@@ -947,9 +1044,22 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
 babylon@^6.14.0, babylon@^6.17.0, babylon@^6.17.2, babylon@^6.17.4:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1208,7 +1318,7 @@ content-type-parser@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
 
-convert-source-map@^1.1.0, convert-source-map@^1.4.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
@@ -1219,6 +1329,10 @@ core-js@^1.0.0:
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+
+core-js@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1985,7 +2099,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.0.0, globals@^9.14.0:
+globals@^9.0.0, globals@^9.14.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -2169,7 +2283,7 @@ interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
-invariant@^2.2.0:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -2641,7 +2755,7 @@ jest@20.0.4:
   dependencies:
     jest-cli "^20.0.4"
 
-js-tokens@^3.0.0:
+js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
@@ -2702,7 +2816,7 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
@@ -3284,7 +3398,7 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
-path-is-absolute@^1.0.0:
+path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
@@ -3364,6 +3478,10 @@ pretty-format@^20.0.3:
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
+
+private@^0.1.7:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -3520,6 +3638,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
 regenerator-transform@0.9.11:
   version "0.9.11"
@@ -3849,6 +3971,12 @@ source-map-support@^0.4.0, source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.4.15:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  dependencies:
+    source-map "^0.5.6"
+
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -4050,7 +4178,7 @@ tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
 
-to-fast-properties@^1.0.1:
+to-fast-properties@^1.0.1, to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,6 +1160,10 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
+colors@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -1872,6 +1876,14 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+fs-extra@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1988,7 +2000,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2693,6 +2705,12 @@ json-stringify-safe@~5.0.1:
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -3663,6 +3681,13 @@ rollup-plugin-commonjs@8.0.2:
     resolve "^1.1.7"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-copy@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-copy/-/rollup-plugin-copy-0.2.3.tgz#dac1ab81d1f220baeb98e5c4c0108252e1edbb98"
+  dependencies:
+    colors "^1.1.2"
+    fs-extra "^3.0.0"
+
 rollup-plugin-css-only@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-css-only/-/rollup-plugin-css-only-0.2.0.tgz#e7c583b2726ff15c88e701ead5c9ad80e1cf4324"
@@ -4094,6 +4119,10 @@ uglify-to-browserify@~1.0.0:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 user-home@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hi @jukben, #26 is done!
- [x] Export all flow type into a file;
- [x] Copy `types.js` to `/dist`;
- [ ] Put Proptypes back / use babel plugin for it
- [x] Copy ES6 code (src folder) into `dist/es6` folder 

I just don't understand why you need the `types` into the `/dist`, because the build doesn't have flow. 

I await your review 😄 
