### PR TITLE
Make closeOnClickOutside work

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -46,6 +46,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "kajmagnus",
+      "name": "KajMagnus",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/7477359?v=4",
+      "profile": "http://www.effectivediscussions.org/",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Enhanced textarea to achieve autocomplete functionality.
 
 [![MIT License][license-badge]][License]
 [![PRs Welcome][prs-badge]][prs]
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
 <hr>
 
 </div>
@@ -222,8 +222,8 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars3.githubusercontent.com/u/8135252?v=4" width="100px;"/><br /><sub><b>Jakub Beneš</b></sub>](https://jukben.cz)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=jukben "Code") [📖](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=jukben "Documentation") [🎨](#design-jukben "Design") [🤔](#ideas-jukben "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/3114719?v=4" width="100px;"/><br /><sub><b>Andrey Taktaev</b></sub>](https://github.com/JokerNN)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=JokerNN "Code") | [<img src="https://avatars0.githubusercontent.com/u/10706203?v=4" width="100px;"/><br /><sub><b>Marcin Lichwała</b></sub>](https://github.com/marcinlichwala)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=marcinlichwala "Code") [📖](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=marcinlichwala "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/9276511?v=4" width="100px;"/><br /><sub><b>Davidson Nascimento</b></sub>](https://github.com/davidsonsns)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=davidsonsns "Code") |
-| :---: | :---: | :---: | :---: |
+| [<img src="https://avatars3.githubusercontent.com/u/8135252?v=4" width="100px;"/><br /><sub><b>Jakub Beneš</b></sub>](https://jukben.cz)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=jukben "Code") [📖](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=jukben "Documentation") [🎨](#design-jukben "Design") [🤔](#ideas-jukben "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/3114719?v=4" width="100px;"/><br /><sub><b>Andrey Taktaev</b></sub>](https://github.com/JokerNN)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=JokerNN "Code") | [<img src="https://avatars0.githubusercontent.com/u/10706203?v=4" width="100px;"/><br /><sub><b>Marcin Lichwała</b></sub>](https://github.com/marcinlichwala)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=marcinlichwala "Code") [📖](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=marcinlichwala "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/9276511?v=4" width="100px;"/><br /><sub><b>Davidson Nascimento</b></sub>](https://github.com/davidsonsns)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=davidsonsns "Code") | [<img src="https://avatars1.githubusercontent.com/u/7477359?v=4" width="100px;"/><br /><sub><b>KajMagnus</b></sub>](http://www.effectivediscussions.org/)<br />[🐛](https://github.com/webscopeio/react-textarea-autocomplete/issues?q=author%3Akajmagnus "Bug reports") [💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=kajmagnus "Code") |
+| :---: | :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -20,6 +20,7 @@ ShallowWrapper {
       className="rta__textarea my-rta"
       onBlur={[Function]}
       onChange={[Function]}
+      onClick={[Function]}
       onSelect={[Function]}
       placeholder="Write a message."
       style={
@@ -43,6 +44,7 @@ ShallowWrapper {
         className="rta__textarea my-rta"
         onBlur={[Function]}
         onChange={[Function]}
+        onClick={[Function]}
         onSelect={[Function]}
         placeholder="Write a message."
         style={
@@ -120,7 +122,7 @@ ShallowWrapper {
         "_getSuggestions": [Function],
         "_getTextToReplace": [Function],
         "_getValuesFromProvider": [Function],
-        "_onBlurHandler": [Function],
+        "_onClickAndBlurHandler": [Function],
         "_onSelect": [Function],
         "_reactInternalInstance": [Circular],
         "_selectHandler": [Function],
@@ -208,6 +210,7 @@ ShallowWrapper {
             className="rta__textarea my-rta"
             onBlur={[Function]}
             onChange={[Function]}
+            onClick={[Function]}
             onSelect={[Function]}
             placeholder="Write a message."
             style={
@@ -231,6 +234,7 @@ ShallowWrapper {
             className="rta__textarea my-rta"
             onBlur={[Function]}
             onChange={[Function]}
+            onClick={[Function]}
             onSelect={[Function]}
             placeholder="Write a message."
             style={
@@ -451,6 +455,7 @@ ShallowWrapper {
       className="rta__textarea ownClassName"
       onBlur={[Function]}
       onChange={[Function]}
+      onClick={[Function]}
       onSelect={[Function]}
       placeholder="Write a message."
       style={
@@ -470,6 +475,7 @@ ShallowWrapper {
         className="rta__textarea ownClassName"
         onBlur={[Function]}
         onChange={[Function]}
+        onClick={[Function]}
         onSelect={[Function]}
         placeholder="Write a message."
         style={
@@ -521,7 +527,7 @@ ShallowWrapper {
         "_getSuggestions": [Function],
         "_getTextToReplace": [Function],
         "_getValuesFromProvider": [Function],
-        "_onBlurHandler": [Function],
+        "_onClickAndBlurHandler": [Function],
         "_onSelect": [Function],
         "_reactInternalInstance": [Circular],
         "_selectHandler": [Function],
@@ -587,6 +593,7 @@ ShallowWrapper {
             className="rta__textarea ownClassName"
             onBlur={[Function]}
             onChange={[Function]}
+            onClick={[Function]}
             onSelect={[Function]}
             placeholder="Write a message."
             style={
@@ -606,6 +613,7 @@ ShallowWrapper {
             className="rta__textarea ownClassName"
             onBlur={[Function]}
             onChange={[Function]}
+            onClick={[Function]}
             onSelect={[Function]}
             placeholder="Write a message."
             style={
@@ -669,6 +677,7 @@ ShallowWrapper {
       className="rta__textarea ownClassName"
       onBlur={[Function]}
       onChange={[Function]}
+      onClick={[Function]}
       onSelect={[Function]}
       placeholder="Write a message."
       style={
@@ -688,6 +697,7 @@ ShallowWrapper {
         className="rta__textarea ownClassName"
         onBlur={[Function]}
         onChange={[Function]}
+        onClick={[Function]}
         onSelect={[Function]}
         placeholder="Write a message."
         style={
@@ -740,7 +750,7 @@ ShallowWrapper {
         "_getSuggestions": [Function],
         "_getTextToReplace": [Function],
         "_getValuesFromProvider": [Function],
-        "_onBlurHandler": [Function],
+        "_onClickAndBlurHandler": [Function],
         "_onSelect": [Function],
         "_reactInternalInstance": [Circular],
         "_selectHandler": [Function],
@@ -807,6 +817,7 @@ ShallowWrapper {
             className="rta__textarea ownClassName"
             onBlur={[Function]}
             onChange={[Function]}
+            onClick={[Function]}
             onSelect={[Function]}
             placeholder="Write a message."
             style={
@@ -826,6 +837,7 @@ ShallowWrapper {
             className="rta__textarea ownClassName"
             onBlur={[Function]}
             onChange={[Function]}
+            onClick={[Function]}
             onSelect={[Function]}
             placeholder="Write a message."
             style={

--- a/cypress/integration/textarea.js
+++ b/cypress/integration/textarea.js
@@ -95,6 +95,20 @@ describe('React Textarea Autocomplete', () => {
       cy.get('.rta__autocomplete').should('not.be.visible');
     });
 
+    it('should be possible to select item with click with closeOnClickOutside option enabled', () => {
+      cy.get('[data-test="clickoutsideOption"]').click();
+
+      cy
+        .get('.rta__textarea')
+        .type('This is test :ro')
+        .get('li:nth-child(2)')
+        .click();
+
+      cy.get('.rta__textarea').should('have.value', 'This is test 🤣');
+
+      cy.get('.rta__autocomplete').should('not.be.visible');
+    });
+
     it('slow request should be "cancelled" when user keep typing', () => {
       cy.get('.rta__textarea').type('This is test @jaku not really');
 

--- a/src/Textarea.jsx
+++ b/src/Textarea.jsx
@@ -398,8 +398,15 @@ class ReactTextareaAutocomplete extends React.Component<
     }
   };
 
-  _onBlurHandler = (e: SyntheticInputEvent<*>) => {
+  _onClickAndBlurHandler = (e: SyntheticInputEvent<*>) => {
     const { closeOnClickOutside, onBlur } = this.props;
+
+    // If this is a click: e.target is the textarea, and e.relatedTarget is the thing
+    // that was actually clicked. If we clicked inside the autoselect dropdown, then
+    // that's not a blur, from the autoselect's point of view, so then do nothing.
+    if (this._dropdown && this._dropdown.contains(e.relatedTarget)) {
+      return;
+    }
 
     if (closeOnClickOutside) {
       this._closeAutocomplete();
@@ -460,13 +467,20 @@ class ReactTextareaAutocomplete extends React.Component<
           className={`rta__textarea ${className || ''}`}
           onChange={this._changeHandler}
           onSelect={this._selectHandler}
-          onBlur={this._onBlurHandler}
+          onClick={
+            // The textarea itself is outside the autoselect dropdown.
+            this._onClickAndBlurHandler
+          }
+          onBlur={this._onClickAndBlurHandler}
           value={value}
           style={style}
         />
         {(dataLoading || suggestionData) &&
           currentTrigger && (
             <div
+              ref={ref => {
+                this._dropdown = ref;
+              }}
               style={{ top, left, ...dropdownStyle }}
               className={`rta__autocomplete ${dropdownClassName || ''}`}
             >

--- a/src/Textarea.jsx
+++ b/src/Textarea.jsx
@@ -398,13 +398,18 @@ class ReactTextareaAutocomplete extends React.Component<
     }
   };
 
-  _onClickAndBlurHandler = (e: SyntheticInputEvent<*>) => {
+  _onClickAndBlurHandler = (e: SyntheticFocusEvent<*>) => {
     const { closeOnClickOutside, onBlur } = this.props;
 
     // If this is a click: e.target is the textarea, and e.relatedTarget is the thing
     // that was actually clicked. If we clicked inside the autoselect dropdown, then
     // that's not a blur, from the autoselect's point of view, so then do nothing.
-    if (this._dropdown && this._dropdown.contains(e.relatedTarget)) {
+    const el = e.relatedTarget;
+    if (
+      this.dropdownRef &&
+      el instanceof Node &&
+      this.dropdownRef.contains(el)
+    ) {
       return;
     }
 
@@ -421,6 +426,8 @@ class ReactTextareaAutocomplete extends React.Component<
   props: TextareaProps;
 
   textareaRef: HTMLInputElement;
+
+  dropdownRef: ?HTMLDivElement;
 
   tokenRegExp: RegExp;
 
@@ -479,7 +486,7 @@ class ReactTextareaAutocomplete extends React.Component<
           currentTrigger && (
             <div
               ref={ref => {
-                this._dropdown = ref;
+                this.dropdownRef = ref;
               }}
               style={{ top, left, ...dropdownStyle }}
               className={`rta__autocomplete ${dropdownClassName || ''}`}


### PR DESCRIPTION
`closeOnClickOutside: true` actually breaks the autocomplete: selecting items no longer works. And clicking inside the textarea doesn't close the dropdown (only clicking outside the textarea, does).

### Steps to reproduce:

`yarn dev`, go to `http://localhost:8080/`

Select `[x] Close when click outside`

- Problem 1:
  Type `@`, "jakub" appears
  Click on "jakupb" — the name disappears, won't get inserted (but it should get selected & inserted).

- Problem 2:
  Type `@` again. "jakub" appears.
  Click inside the textarea (but not on "jakub"). Nothingh appens (but the dropdown should close).

This works though:
- Type `@`, click outsied the textarea. Now the dropdown closes.

This PR fixes problems 1 and 2 above.