### PR TITLE
Cleans up dropdownStyle from textarea props

### DIFF
--- a/src/Textarea.jsx
+++ b/src/Textarea.jsx
@@ -314,6 +314,7 @@ class ReactTextareaAutocomplete extends React.Component<
       'loaderClassName',
       'closeOnClickOutside',
       'dropdownStyle',
+      'dropdownClassName',
     ];
 
     // eslint-disable-next-line

--- a/src/Textarea.jsx
+++ b/src/Textarea.jsx
@@ -313,6 +313,7 @@ class ReactTextareaAutocomplete extends React.Component<
       'itemClassName',
       'loaderClassName',
       'closeOnClickOutside',
+      'dropdownStyle',
     ];
 
     // eslint-disable-next-line


### PR DESCRIPTION
Cleans up dropdownStyle from props so it doesn't get applied to `<textarea>` and throwing a warning from React.