### PR TITLE
Allows embedded keys with data

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -86,6 +86,16 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "alecklandgraf",
+      "name": "Aleck Landgraf",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/2336595?v=4",
+      "profile": "http://aleck.me",
+      "contributions": [
+        "code"
+      ]
     }
-  ]
+  ],
+  "repoType": "github"
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Enhanced textarea to achieve autocomplete functionality.
 
 [![MIT License][license-badge]][License]
 [![PRs Welcome][prs-badge]][prs]
-[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors)
 <hr>
 
 </div>
@@ -118,9 +118,20 @@ export default App;
 ```javascript 
 {
     [triggerChar: string]: {|
-        ?output: (item: Object | string, trigger?: string) => {| text: string, caretPosition: "start" | "end" | "next" | number |} | string,
-        dataProvider: (token: string) => Promise<Array<Object | string>> | Array<Object | string>,
-        component: ReactClass<*>,
+      output?: (
+        item: Object | string,
+        trigger?: string
+      ) =>
+        | {|
+            key?: string | number,
+            text: string,
+            caretPosition: "start" | "end" | "next" | number
+          |}
+        | string,
+      dataProvider: (
+        token: string
+      ) => Promise<Array<Object | string>> | Array<Object | string>,
+      component: ReactClass<*>
     |},
 }
 ```
@@ -131,7 +142,7 @@ export default App;
 
    You can also specify the behavior of caret if you return object `{text: "item", caretPosition: "start"}` the caret will be before the word once the user confirms his selection. Other possible value are "next", "end" and number, which is absolute number in contex of textarea (0 is equal position before the first char). Defaults to "next" which is space after the injected word.
  
-   Default behavior for string based item is string: `<TRIGGER><ITEM><TRIGGER>`). This method should **always** return a unique string.
+   Default behavior for string based item is string: `<TRIGGER><ITEM><TRIGGER>`). This method should **always** return a unique string, otherwise you have to use object notation and specify your own `key`.
 
 ## [Example of usage](http://react-textarea-autocomplete.surge.sh/)
 `create-react-app example && cd example && yarn add @jukben/emoji-search @webscopeio/react-textarea-autocomplete`
@@ -225,7 +236,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
 <!-- prettier-ignore -->
 | [<img src="https://avatars3.githubusercontent.com/u/8135252?v=4" width="100px;"/><br /><sub><b>Jakub Beneš</b></sub>](https://jukben.cz)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=jukben "Code") [📖](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=jukben "Documentation") [🎨](#design-jukben "Design") [🤔](#ideas-jukben "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/3114719?v=4" width="100px;"/><br /><sub><b>Andrey Taktaev</b></sub>](https://github.com/JokerNN)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=JokerNN "Code") | [<img src="https://avatars0.githubusercontent.com/u/10706203?v=4" width="100px;"/><br /><sub><b>Marcin Lichwała</b></sub>](https://github.com/marcinlichwala)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=marcinlichwala "Code") [📖](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=marcinlichwala "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/9276511?v=4" width="100px;"/><br /><sub><b>Davidson Nascimento</b></sub>](https://github.com/davidsonsns)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=davidsonsns "Code") | [<img src="https://avatars1.githubusercontent.com/u/7477359?v=4" width="100px;"/><br /><sub><b>KajMagnus</b></sub>](http://www.effectivediscussions.org/)<br />[🐛](https://github.com/webscopeio/react-textarea-autocomplete/issues?q=author%3Akajmagnus "Bug reports") [💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=kajmagnus "Code") | [<img src="https://avatars2.githubusercontent.com/u/1083817?v=4" width="100px;"/><br /><sub><b>Ján Vorčák</b></sub>](https://twitter.com/janvorcak)<br />[🐛](https://github.com/webscopeio/react-textarea-autocomplete/issues?q=author%3Ajvorcak "Bug reports") [💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=jvorcak "Code") | [<img src="https://avatars2.githubusercontent.com/u/9800850?v=4" width="100px;"/><br /><sub><b>Mateusz Burzyński</b></sub>](https://github.com/Andarist)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=Andarist "Code") [📦](#platform-Andarist "Packaging/porting to new platform") |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| [<img src="https://avatars0.githubusercontent.com/u/35139777?v=4" width="100px;"/><br /><sub><b>Deepak Pai</b></sub>](https://github.com/debugpai2)<br />[🐛](https://github.com/webscopeio/react-textarea-autocomplete/issues?q=author%3Adebugpai2 "Bug reports") [💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=debugpai2 "Code") |
+| [<img src="https://avatars0.githubusercontent.com/u/35139777?v=4" width="100px;"/><br /><sub><b>Deepak Pai</b></sub>](https://github.com/debugpai2)<br />[🐛](https://github.com/webscopeio/react-textarea-autocomplete/issues?q=author%3Adebugpai2 "Bug reports") [💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=debugpai2 "Code") | [<img src="https://avatars0.githubusercontent.com/u/2336595?v=4" width="100px;"/><br /><sub><b>Aleck Landgraf</b></sub>](http://aleck.me)<br />[💻](https://github.com/webscopeio/react-textarea-autocomplete/commits?author=alecklandgraf "Code") |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ export default App;
         trigger?: string
       ) =>
         | {|
-            key?: string | number,
+            key?: ?string,
             text: string,
             caretPosition: "start" | "end" | "next" | number
           |}

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -157,6 +157,207 @@ exports[`object-based items match the snapshot of dropdown, list, and item 3`] =
 </li>
 `;
 
+exports[`object-based items with keys match the snapshot 1`] = `
+<div
+  className="rta  my-rta-container"
+  style={
+    Object {
+      "background": "orange",
+    }
+  }
+>
+  <textarea
+    className="rta__textarea my-rta"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onClick={[Function]}
+    onSelect={[Function]}
+    placeholder="Write a message."
+    style={
+      Object {
+        "background": "red",
+      }
+    }
+    value="Controlled text"
+  />
+</div>
+`;
+
+exports[`object-based items with keys match the snapshot of dropdown, list, and item 1`] = `
+<div
+  class="rta__autocomplete "
+>
+  <ul
+    class="rta__list my-rta-list"
+  >
+    <li
+      class="rta__item my-rta-item"
+      style="background: green;"
+    >
+      <div
+        class="rta__entity rta__entity--selected"
+        role="button"
+        tabindex="0"
+      >
+        <div>
+          <!-- react-text: 10 -->
+           
+          <!-- /react-text -->
+          <!-- react-text: 11 -->
+          :)
+          <!-- /react-text -->
+          <!-- react-text: 12 -->
+           
+          <!-- /react-text -->
+        </div>
+      </div>
+    </li>
+    <li
+      class="rta__item my-rta-item"
+      style="background: green;"
+    >
+      <div
+        class="rta__entity "
+        role="button"
+        tabindex="0"
+      >
+        <div>
+          <!-- react-text: 16 -->
+           
+          <!-- /react-text -->
+          <!-- react-text: 17 -->
+          :(
+          <!-- /react-text -->
+          <!-- react-text: 18 -->
+           
+          <!-- /react-text -->
+        </div>
+      </div>
+    </li>
+    <li
+      class="rta__item my-rta-item"
+      style="background: green;"
+    >
+      <div
+        class="rta__entity "
+        role="button"
+        tabindex="0"
+      >
+        <div>
+          <!-- react-text: 22 -->
+           
+          <!-- /react-text -->
+          <!-- react-text: 23 -->
+          :|
+          <!-- /react-text -->
+          <!-- react-text: 24 -->
+           
+          <!-- /react-text -->
+        </div>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`object-based items with keys match the snapshot of dropdown, list, and item 2`] = `
+<ul
+  class="rta__list my-rta-list"
+>
+  <li
+    class="rta__item my-rta-item"
+    style="background: green;"
+  >
+    <div
+      class="rta__entity rta__entity--selected"
+      role="button"
+      tabindex="0"
+    >
+      <div>
+        <!-- react-text: 10 -->
+         
+        <!-- /react-text -->
+        <!-- react-text: 11 -->
+        :)
+        <!-- /react-text -->
+        <!-- react-text: 12 -->
+         
+        <!-- /react-text -->
+      </div>
+    </div>
+  </li>
+  <li
+    class="rta__item my-rta-item"
+    style="background: green;"
+  >
+    <div
+      class="rta__entity "
+      role="button"
+      tabindex="0"
+    >
+      <div>
+        <!-- react-text: 16 -->
+         
+        <!-- /react-text -->
+        <!-- react-text: 17 -->
+        :(
+        <!-- /react-text -->
+        <!-- react-text: 18 -->
+         
+        <!-- /react-text -->
+      </div>
+    </div>
+  </li>
+  <li
+    class="rta__item my-rta-item"
+    style="background: green;"
+  >
+    <div
+      class="rta__entity "
+      role="button"
+      tabindex="0"
+    >
+      <div>
+        <!-- react-text: 22 -->
+         
+        <!-- /react-text -->
+        <!-- react-text: 23 -->
+        :|
+        <!-- /react-text -->
+        <!-- react-text: 24 -->
+         
+        <!-- /react-text -->
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`object-based items with keys match the snapshot of dropdown, list, and item 3`] = `
+<li
+  class="rta__item my-rta-item"
+  style="background: green;"
+>
+  <div
+    class="rta__entity rta__entity--selected"
+    role="button"
+    tabindex="0"
+  >
+    <div>
+      <!-- react-text: 10 -->
+       
+      <!-- /react-text -->
+      <!-- react-text: 11 -->
+      :)
+      <!-- /react-text -->
+      <!-- react-text: 12 -->
+       
+      <!-- /react-text -->
+    </div>
+  </div>
+</li>
+`;
+
 exports[`string-based items w/o output fn match match the snapshot 1`] = `
 <div
   className="rta  "

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -320,3 +320,50 @@ describe('using ref to the ReactTextareaAutocomplete to call methods', () => {
     expect(actual).toBe(expected);
   });
 });
+
+describe('data provided with keys', () => {
+  const mockedChangeFn = jest.fn();
+  const mockedSelectFn = jest.fn();
+  const mockedCaretPositionChangeFn = jest.fn();
+
+  const createRtaComponent = override => (
+    <ReactTextareaAutocomplete
+      listStyle={{ background: 'pink' }}
+      itemStyle={{ background: 'green' }}
+      containerStyle={{ background: 'orange' }}
+      loaderStyle={{ background: 'blue' }}
+      className="my-rta"
+      containerClassName="my-rta-container"
+      listClassName="my-rta-list"
+      itemClassName="my-rta-item"
+      loaderClassName="my-rta-loader"
+      placeholder={'Write a message.'}
+      value={'Controlled text'}
+      onChange={mockedChangeFn}
+      onSelect={mockedSelectFn}
+      onCaretPositionChange={mockedCaretPositionChangeFn}
+      style={{ background: 'red' }}
+      loadingComponent={Loading}
+      trigger={{
+        ':': {
+          output: item => `___${item.text}___`,
+          dataProvider: () => [
+            { key: '1', label: ':)', text: 'sad_face' },
+            { key: '2', label: ':(', text: 'sad_face' },
+          ],
+          component: SmileItemComponent,
+        },
+      }}
+      {...override}
+    />
+  );
+
+  it('Duplicate values should not error if keys are provided', () => {
+    const rtaComponent = createRtaComponent();
+    const rta = mount(rtaComponent);
+    rta
+      .find('textarea')
+      .simulate('change', { target: { value: 'some test :a' } });
+    expect(rta.find('.rta__autocomplete')).toHaveLength(1);
+  });
+});

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { shallow, mount } from 'enzyme';
 import ReactTextareaAutocomplete from '../src';
+import Item from '../src/Item';
 
 // eslint-disable-next-line
 const SmileItemComponent = ({ entity: { label, text } }) => <div> {label} </div>;
@@ -76,6 +77,12 @@ describe('object-based items', () => {
     expect(rta.find('.rta__autocomplete .rta__list .rta__item')).toHaveLength(
       2
     );
+  });
+
+  it('should use the create a key from the output function if no key is provided', () => {
+    const items = rta.find(Item);
+    expect(items.at(0).key()).toEqual('___happy_face___');
+    expect(items.at(1).key()).toEqual('___sad_face___');
   });
 
   it('items should be rendered within the component', () => {
@@ -321,12 +328,12 @@ describe('using ref to the ReactTextareaAutocomplete to call methods', () => {
   });
 });
 
-describe('data provided with keys', () => {
+describe('object-based items with keys', () => {
   const mockedChangeFn = jest.fn();
   const mockedSelectFn = jest.fn();
   const mockedCaretPositionChangeFn = jest.fn();
 
-  const createRtaComponent = override => (
+  const rtaComponent = (
     <ReactTextareaAutocomplete
       listStyle={{ background: 'pink' }}
       itemStyle={{ background: 'green' }}
@@ -348,22 +355,93 @@ describe('data provided with keys', () => {
         ':': {
           output: item => `___${item.text}___`,
           dataProvider: () => [
-            { key: '1', label: ':)', text: 'sad_face' },
-            { key: '2', label: ':(', text: 'sad_face' },
+            { key: '1', label: ':)', text: 'happy_face' },
+            { key: 'some id', label: ':(', text: 'sad_face' },
+            { key: 3, label: ':|', text: 'sad_face' },
           ],
           component: SmileItemComponent,
         },
       }}
-      {...override}
     />
   );
+  const rta = mount(rtaComponent);
 
-  it('Duplicate values should not error if keys are provided', () => {
-    const rtaComponent = createRtaComponent();
-    const rta = mount(rtaComponent);
+  it('match the snapshot', () => {
+    expect(shallow(rtaComponent)).toMatchSnapshot();
+  });
+
+  it('Textarea exists', () => {
+    expect(rta.find('textarea')).toHaveLength(1);
+  });
+
+  it('After the trigger was typed, it should appear list of options', () => {
     rta
       .find('textarea')
       .simulate('change', { target: { value: 'some test :a' } });
     expect(rta.find('.rta__autocomplete')).toHaveLength(1);
+  });
+
+  it('match the snapshot of dropdown, list, and item', () => {
+    expect(rta.find('.rta__autocomplete').getNode()).toMatchSnapshot();
+    expect(
+      rta.find('.rta__autocomplete .rta__list').getNode()
+    ).toMatchSnapshot();
+    expect(
+      rta
+        .find('.rta__autocomplete .rta__list .rta__item')
+        .first()
+        .getNode()
+    ).toMatchSnapshot();
+  });
+
+  it('should display all items', () => {
+    expect(rta.find('.rta__autocomplete .rta__list .rta__item')).toHaveLength(
+      3
+    );
+  });
+
+  it('should use the key property from the data obejct', () => {
+    const items = rta.find(Item);
+    expect(items.at(0).key()).toEqual('1');
+    expect(items.at(1).key()).toEqual('some id');
+    expect(items.at(2).key()).toEqual('3');
+  });
+
+  it('items should be rendered within the component', () => {
+    expect(
+      rta
+        .find('.rta__item')
+        .first()
+        .containsMatchingElement(<SmileItemComponent />)
+    ).toEqual(true);
+  });
+
+  it('should invoke onChange handler', () => {
+    expect(mockedChangeFn).toHaveBeenCalled();
+  });
+
+  it('should handle selection in textarea correctly', () => {
+    rta.find('textarea').simulate('select');
+    expect(mockedCaretPositionChangeFn).toHaveBeenCalled();
+  });
+
+  it('should close the autocomplete after mouse click', () => {
+    const item = rta.find('.rta__entity').first();
+    item.simulate('click');
+    expect(rta.find('.rta__entity')).toHaveLength(0);
+  });
+
+  it('should invoke onChange handler after selection', () => {
+    expect(mockedChangeFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should invoke onCaretPositionChange handler after selection', () => {
+    expect(mockedCaretPositionChangeFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('text in textarea should be changed', () => {
+    expect(rta.find('textarea').node.value).toBe(
+      '___happy_face___ some test :a'
+    );
   });
 });

--- a/src/List.jsx
+++ b/src/List.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import Listeners, { KEY_CODES } from './listener';
 import Item from './Item';
-import type { ListProps, ListState } from './types';
+import type { ListProps, ListState, OutputItem } from './types';
 
 export default class List extends React.Component<ListProps, ListState> {
   state: ListState = {
@@ -50,8 +50,13 @@ export default class List extends React.Component<ListProps, ListState> {
     return values.findIndex(a => this.getId(a) === this.getId(selectedItem));
   };
 
-  getId = (item: Object | string): string =>
-    this.props.getTextToReplace(item).text;
+  getId = (item: OutputItem | string): string => {
+    if (typeof item === 'string' || typeof item.key === 'undefined') {
+      return this.props.getTextToReplace(item).text;
+    }
+
+    return item.key;
+  };
 
   props: ListProps;
 

--- a/src/List.jsx
+++ b/src/List.jsx
@@ -51,11 +51,11 @@ export default class List extends React.Component<ListProps, ListState> {
   };
 
   getId = (item: textToReplaceType | string): string => {
-    if (typeof item === 'string' || typeof item.key === 'undefined') {
+    if (typeof item === 'string' || !item.key) {
       return this.props.getTextToReplace(item).text;
     }
 
-    return String(item.key);
+    return item.key;
   };
 
   props: ListProps;

--- a/src/List.jsx
+++ b/src/List.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import Listeners, { KEY_CODES } from './listener';
 import Item from './Item';
-import type { ListProps, ListState, OutputItem } from './types';
+import type { ListProps, ListState, textToReplaceType } from './types';
 
 export default class List extends React.Component<ListProps, ListState> {
   state: ListState = {
@@ -50,12 +50,12 @@ export default class List extends React.Component<ListProps, ListState> {
     return values.findIndex(a => this.getId(a) === this.getId(selectedItem));
   };
 
-  getId = (item: OutputItem | string): string => {
+  getId = (item: textToReplaceType | string): string => {
     if (typeof item === 'string' || typeof item.key === 'undefined') {
       return this.props.getTextToReplace(item).text;
     }
 
-    return item.key;
+    return String(item.key);
   };
 
   props: ListProps;

--- a/src/Textarea.jsx
+++ b/src/Textarea.jsx
@@ -21,7 +21,9 @@ const DEFAULT_CARET_POSITION = 'next';
 
 const errorMessage = (message: string) =>
   console.error(
-    `RTA: dataProvider fails: ${message} Check the documentation or create issue if you think it's bug. https://github.com/webscopeio/react-textarea-autocomplete/issues`
+    `RTA: dataProvider fails: ${
+      message
+    } Check the documentation or create issue if you think it's bug. https://github.com/webscopeio/react-textarea-autocomplete/issues`
   );
 class ReactTextareaAutocomplete extends React.Component<
   TextareaProps,

--- a/src/Textarea.jsx
+++ b/src/Textarea.jsx
@@ -261,7 +261,7 @@ class ReactTextareaAutocomplete extends React.Component<
 
     providedData
       .then(data => {
-        if (Object.prototype.toString.call(data) !== '[object Array]') {
+        if (!Array.isArray(data)) {
           throw new Error('Trigger provider has to provide an array!');
         }
 

--- a/src/Textarea.jsx
+++ b/src/Textarea.jsx
@@ -21,9 +21,7 @@ const DEFAULT_CARET_POSITION = 'next';
 
 const errorMessage = (message: string) =>
   console.error(
-    `RTA: dataProvider fails: ${
-      message
-    } Check the documentation or create issue if you think it's bug. https://github.com/webscopeio/react-textarea-autocomplete/issues`
+    `RTA: dataProvider fails: ${message} Check the documentation or create issue if you think it's bug. https://github.com/webscopeio/react-textarea-autocomplete/issues`
   );
 class ReactTextareaAutocomplete extends React.Component<
   TextareaProps,
@@ -261,7 +259,7 @@ class ReactTextareaAutocomplete extends React.Component<
 
     providedData
       .then(data => {
-        if (typeof providedData !== 'object') {
+        if (Object.prototype.toString.call(data) !== '[object Array]') {
           throw new Error('Trigger provider has to provide an array!');
         }
 

--- a/src/types.js
+++ b/src/types.js
@@ -5,6 +5,7 @@ export type caretPositionType = 'start' | 'end' | 'next' | number;
 export type textToReplaceType = {|
   text: string,
   caretPosition: caretPositionType,
+  key?: ?string,
 |};
 
 export type outputType = (Object | string, ?string) => textToReplaceType;
@@ -93,8 +94,4 @@ export type TextareaState = {
   selectionEnd: number,
   selectionStart: number,
   component: ?React$StatelessFunctionalComponent<*>,
-};
-
-export type OutputItem = {
-  key: string,
 };

--- a/src/types.js
+++ b/src/types.js
@@ -94,3 +94,7 @@ export type TextareaState = {
   selectionStart: number,
   component: ?React$StatelessFunctionalComponent<*>,
 };
+
+export type OutputItem = {
+  key: string,
+};


### PR DESCRIPTION
Add support for using RTA with duplicate values. 

Say you want `beer`, `happy_hour`, and `draft` to return the same emoji, 🍺, this change allows that.

I also fixed what I think was a invalid check of `data`'s type.