### PR TITLE
Add parameter to prevent scrollintoView from aligning to top

### DIFF
--- a/src/List.jsx
+++ b/src/List.jsx
@@ -81,7 +81,7 @@ export default class List extends React.Component<ListProps, ListState> {
 
   selectItem = (item: Object | string) => {
     this.setState({ selectedItem: item }, () => {
-      this.itemsRef[this.getId(item)].scrollIntoView();
+      this.itemsRef[this.getId(item)].scrollIntoView(false);
     });
   };
 


### PR DESCRIPTION
Was having many issues with the alignTop functionality, and so this param disables it which is less jarring. Still allows the selected item to scroll into view correctly. 

Documentation here: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView 