### PR TITLE
Fix prop-types peerDep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "webpack-dev-server": "3.1.14"
   },
   "peerDependencies": {
-    "prop-types": "^16.0.0",
+    "prop-types": "^15.0.0",
     "react": "^16.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Super minor fix :)

`prop-types` package doesn't have version 16 yet and yarn throws warning because of it.