### PR TITLE
Fix react-dom peerDep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "peerDependencies": {
     "prop-types": "^15.0.0",
     "react": "^16.0.0",
-    "react-dom": "16.6.0"
+    "react-dom": "^16.6.0"
   },
   "dependencies": {
     "custom-event": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "peerDependencies": {
     "prop-types": "^15.0.0",
     "react": "^16.0.0",
-    "react-dom": "^16.6.0"
+    "react-dom": "^16.0.0"
   },
   "dependencies": {
     "custom-event": "^1.0.1",


### PR DESCRIPTION
Yarn shows warning when installing `warning " > @webscopeio/react-textarea-autocomplete@4.4.0" has incorrect peer dependency "react-dom@16.6.0".`

I believe version should be like this "react-dom@^16.6.0" to allow minor and patch versions too!)