### PR TITLE
also publish index.d.ts for easier typescript interop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cypress/screenshots
 dist/
 example-build/
 types.js
+index.d.ts

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "files": [
     "dist",
     "types.js",
+    "index.d.ts",
     "style.css"
   ],
   "main": "dist/react-textarea-autocomplete.cjs.js",
@@ -27,7 +28,7 @@
     "react"
   ],
   "scripts": {
-    "build": "cp src/types.js types.js && rollup -c",
+    "build": "cp src/types.js types.js && cp src/types.js index.d.ts && rollup -c",
     "dev": "yarn run example --open",
     "example": "webpack-dev-server --config webpack.dev.config.js",
     "example:build": "webpack --config webpack.prod.config.js",


### PR DESCRIPTION
I am no typescript expert, but i believe this would make it easier to consume this awesome lib in typescript project without going through extra hoops such as https://www.npmjs.com/package/@types/webscopeio__react-textarea-autocomplete