### PR TITLE
fix: suggestion position is wrong

### DIFF
--- a/src/Textarea.jsx
+++ b/src/Textarea.jsx
@@ -155,15 +155,16 @@ class Autocomplete extends React.Component<AutocompleteProps> {
       left +
       dropdownBounds.width;
 
-    if (dropdownRight > containerBounds.right) {
-      leftPosition = left - dropdownBounds.width;
-      usedClasses.push(POSITION_CONFIGURATION.X.LEFT);
-      unusedClasses.push(POSITION_CONFIGURATION.X.RIGHT);
-    } else {
-      leftPosition = left;
-      usedClasses.push(POSITION_CONFIGURATION.X.RIGHT);
-      unusedClasses.push(POSITION_CONFIGURATION.X.LEFT);
-    }
+      if (dropdownRight > containerBounds.right &&
+        textareaBounds.left + left > dropdownBounds.width) {
+        leftPosition = left - dropdownBounds.width;
+        usedClasses.push(POSITION_CONFIGURATION.X.LEFT);
+        unusedClasses.push(POSITION_CONFIGURATION.X.RIGHT);
+      } else {
+        leftPosition = left;
+        usedClasses.push(POSITION_CONFIGURATION.X.RIGHT);
+        unusedClasses.push(POSITION_CONFIGURATION.X.LEFT);
+      }
 
     if (dropdownBottom > containerBounds.bottom && 
       textareaBounds.top + top > dropdownBounds.height) {

--- a/src/Textarea.jsx
+++ b/src/Textarea.jsx
@@ -165,7 +165,8 @@ class Autocomplete extends React.Component<AutocompleteProps> {
       unusedClasses.push(POSITION_CONFIGURATION.X.LEFT);
     }
 
-    if (dropdownBottom > containerBounds.bottom) {
+    if (dropdownBottom > containerBounds.bottom && 
+      textareaBounds.top + top > dropdownBounds.height) {
       topPosition = top - dropdownBounds.height;
       usedClasses.push(POSITION_CONFIGURATION.Y.TOP);
       unusedClasses.push(POSITION_CONFIGURATION.Y.BOTTOM);


### PR DESCRIPTION
Dropdown only goes upwards if there's enough room to the top of the container to place it entirely. If the dropdown would overflow both the top and bottom of the container, then default to overflow the bottom so that you can see the first item.
 
fix #209 