### PR TITLE
Add support for v18 of react and react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.0.0",
-    "react": "^16.0.0 || ^17",
-    "react-dom": "^16.0.0 || ^17"
+    "react": "^16.0.0 || ^17 || ^18",
+    "react-dom": "^16.0.0 || ^17 || ^18"
   },
   "dependencies": {
     "custom-event": "^1.0.1",


### PR DESCRIPTION
I wanted to update a project to use v18 of React and noticed [this issue](https://github.com/webscopeio/react-textarea-autocomplete/issues/234). 

I've only updated the expected peer dependency of `react` and `react-dom` to allow **v18**, but if other maintainers would like me to bump the actual dependency (and edit the example index for new `createRoot` syntax) as well, I'm more than happy to do so. In my local testing with react and react-dom v18.2.0, this worked the same as before. Thanks! 